### PR TITLE
globally_quoted_identifiers = true

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5Dialect
+        globally_quoted_identifiers: true
 
 
 server:


### PR DESCRIPTION
Group table adı reserved keyword olduğu üçün Hibernate bu cədvəli MariaDB-də create edərkən SQL Syntax xətası alırdı. Belə xətaların olmaması üçün cədvəl adı dırnaq içində yazılmalıdır. `application.yaml` faylına müvafiq konfiqurasiyanı əlavə etdim.

Before:
![Screen_Shot_2022-06-13_at_12 05 00_AM](https://user-images.githubusercontent.com/49293712/173252060-ae3a8b9b-d3c9-435b-8aba-678b86a8bb4d.png)

After:
<img width="1512" alt="Screen Shot 2022-06-13 at 12 23 04 AM" src="https://user-images.githubusercontent.com/49293712/173252206-eb9506ff-44dd-428b-b631-6784ebc48458.png">

